### PR TITLE
feat: Add basic admin panel structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,78 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
-import Home from './pages/Home'
-import About from './pages/About'
-import Education from './pages/Education'
-import Teachers from './pages/Teachers'
-import Gallery from './pages/Gallery'
-import News from './pages/News'
-import Contact from './pages/Contact'
-import './App.css'
+import Home from './pages/Home';
+import About from './pages/About';
+import Education from './pages/Education';
+import Teachers from './pages/Teachers';
+import Gallery from './pages/Gallery';
+import News from './pages/News';
+import Contact from './pages/Contact';
+import './App.css';
+
+// Admin components
+import AdminLayout from './components/admin/AdminLayout';
+import DashboardPage from './pages/admin/DashboardPage';
+import LoginPage from './pages/admin/LoginPage'; // LoginPage import edildi
+import HomePageSettings from './pages/admin/HomePageSettings'; // HomePageSettings import edildi
+import AboutPageSettings from './pages/admin/AboutPageSettings'; // AboutPageSettings import edildi
+import EducationPageSettings from './pages/admin/EducationPageSettings';
+import GalleryPageSettings from './pages/admin/GalleryPageSettings';
+import NewsPageSettings from './pages/admin/NewsPageSettings';
+import TeachersPageSettings from './pages/admin/TeachersPageSettings';
+import ContactPageSettings from './pages/admin/ContactPageSettings';
+
+// Artık gerçek component'ler kullanıldığı için eski placeholder tanımlarına gerek yok.
+
+// Site Layout (Header ve Footer'ı içerir)
+const SiteLayout = ({ children }: { children: React.ReactNode }) => (
+  <div className="min-h-screen bg-gradient-to-br from-green-50 to-yellow-50">
+    <Header />
+    <main>{children}</main>
+    <Footer />
+  </div>
+);
 
 function App() {
   return (
     <Router>
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-yellow-50">
-        <Header />
-        <main>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/hakkimizda" element={<About />} />
-            <Route path="/egitimler" element={<Education />} />
-            <Route path="/ogretmenlerimiz" element={<Teachers />} />
-            <Route path="/galeri" element={<Gallery />} />
-            <Route path="/duyurular" element={<News />} />
-            <Route path="/iletisim" element={<Contact />} />
-          </Routes>
-        </main>
-        <Footer />
-      </div>
+      <Routes>
+        {/* Site Routes */}
+        <Route
+          path="/*"
+          element={
+            <SiteLayout>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/hakkimizda" element={<About />} />
+                <Route path="/egitimler" element={<Education />} />
+                <Route path="/ogretmenlerimiz" element={<Teachers />} />
+                <Route path="/galeri" element={<Gallery />} />
+                <Route path="/duyurular" element={<News />} />
+                <Route path="/iletisim" element={<Contact />} />
+                {/* Diğer site sayfaları buraya eklenebilir */}
+              </Routes>
+            </SiteLayout>
+          }
+        />
+
+        {/* Admin Routes */}
+        <Route path="/admin/login" element={<LoginPage />} />
+        <Route path="/admin" element={<AdminLayout />}>
+          <Route path="dashboard" element={<DashboardPage />} />
+          <Route path="home-settings" element={<HomePageSettings />} />
+          <Route path="about-settings" element={<AboutPageSettings />} />
+          <Route path="education-settings" element={<EducationPageSettings />} />
+          <Route path="gallery-settings" element={<GalleryPageSettings />} />
+          <Route path="news-settings" element={<NewsPageSettings />} />
+          <Route path="teachers-settings" element={<TeachersPageSettings />} />
+          <Route path="contact-settings" element={<ContactPageSettings />} />
+          {/* Admin paneli için varsayılan sayfa (opsiyonel) */}
+          <Route index element={<DashboardPage />} />
+        </Route>
+      </Routes>
     </Router>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import AdminSidebar from './AdminSidebar';
+// import AdminHeader from './AdminHeader'; // Opsiyonel: Eğer bir header da olacaksa
+
+const AdminLayout: React.FC = () => {
+  return (
+    <div className="flex h-screen bg-gray-100">
+      <AdminSidebar />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* <AdminHeader /> // Opsiyonel Header */}
+        <main className="flex-1 overflow-x-hidden overflow-y-auto bg-background p-6">
+          <Outlet /> {/* Admin sayfaları burada render edilecek */}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { Home, Info, Settings, LayoutDashboard, Newspaper, Image, Users, Phone } from 'lucide-react'; // İkonlar
+
+const AdminSidebar: React.FC = () => {
+  const navItems = [
+    { to: '/admin/dashboard', icon: <LayoutDashboard size={20} />, label: 'Dashboard' },
+    { to: '/admin/home-settings', icon: <Home size={20} />, label: 'Anasayfa Yönetimi' },
+    { to: '/admin/about-settings', icon: <Info size={20} />, label: 'Hakkımızda Yönetimi' },
+    { to: '/admin/education-settings', icon: <Settings size={20} />, label: 'Eğitim Yönetimi' }, // Assuming Settings icon for now
+    { to: '/admin/gallery-settings', icon: <Image size={20} />, label: 'Galeri Yönetimi' },
+    { to: '/admin/news-settings', icon: <Newspaper size={20} />, label: 'Haberler Yönetimi' },
+    { to: '/admin/teachers-settings', icon: <Users size={20} />, label: 'Öğretmenler Yönetimi' },
+    { to: '/admin/contact-settings', icon: <Phone size={20} />, label: 'İletişim Yönetimi' },
+    // Gelecekte eklenebilecek diğer linkler
+    // { to: '/admin/settings', icon: <Settings size={20} />, label: 'Genel Ayarlar' },
+  ];
+
+  return (
+    <aside className="w-64 bg-sidebar border-r border-sidebar-border text-sidebar-foreground p-4 space-y-2">
+      <div className="text-2xl font-bold text-primary mb-6 px-2">
+        Admin Paneli
+      </div>
+      <nav>
+        <ul>
+          {navItems.map((item) => (
+            <li key={item.to}>
+              <NavLink
+                to={item.to}
+                className={({ isActive }) =>
+                  `flex items-center space-x-3 px-3 py-2.5 rounded-md text-sm font-medium transition-colors
+                  ${isActive
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                  }`
+                }
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default AdminSidebar;

--- a/src/pages/admin/AboutPageSettings.tsx
+++ b/src/pages/admin/AboutPageSettings.tsx
@@ -1,0 +1,213 @@
+import React, { useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { PlusCircle, Edit, Trash2, Save, Users, Target, Eye, Award, Calendar, ListChecks } from "lucide-react";
+
+// Örnek veri tipleri (About.tsx'e benzer)
+interface StatItem {
+  id: string;
+  // icon: string; // İkon seçimi
+  iconName: string;
+  number: string;
+  label: string;
+}
+
+interface PrincipleItem {
+  id: string;
+  // icon: string;
+  iconName: string;
+  title: string;
+  description: string;
+}
+
+interface TimelineItem {
+  id: string;
+  year: string;
+  title: string;
+  description: string;
+}
+
+// Mock Data (Başlangıç için)
+const initialStats: StatItem[] = [
+  { id: '1', iconName: 'Users', number: '150+', label: 'Mutlu Çocuk' },
+  { id: '2', iconName: 'Award', number: '15+', label: 'Yıllık Deneyim' },
+];
+
+const AboutPageSettings: React.FC = () => {
+  const [stats, setStats] = useState<StatItem[]>(initialStats);
+  const [mission, setMission] = useState<string>(
+    "Çocuklarımızın mutlu, sağlıklı, özgüvenli ve yaratıcı bireyler olarak..." // About.tsx'den kısaltılmış örnek
+  );
+  const [vision, setVision] = useState<string>(
+    "Türkiye'nin önde gelen anaokulu markası olarak..." // About.tsx'den kısaltılmış örnek
+  );
+
+  // TODO: Diğer bölümler için CRUD fonksiyonları ve formlar eklenecek
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Hakkımızda Sayfası İçerik Yönetimi</h1>
+
+      <Tabs defaultValue="stats" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 md:grid-cols-3 lg:grid-cols-5 mb-4">
+          <TabsTrigger value="stats">İstatistikler</TabsTrigger>
+          <TabsTrigger value="mission_vision">Misyon & Vizyon</TabsTrigger>
+          <TabsTrigger value="principles">Eğitim İlkeleri</TabsTrigger>
+          <TabsTrigger value="timeline">Tarihçe</TabsTrigger>
+          <TabsTrigger value="why_us">Neden Biz?</TabsTrigger>
+        </TabsList>
+
+        {/* İstatistikler Yönetimi */}
+        <TabsContent value="stats">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                İstatistikler
+                <Button size="sm" onClick={() => alert("Yeni istatistik ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni İstatistik Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>"Hakkımızda" sayfasındaki istatistikleri yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {stats.map((stat) => (
+                <Card key={stat.id} className="p-4 shadow-sm">
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <h3 className="font-semibold text-lg">{stat.label} ({stat.number})</h3>
+                      <p className="text-sm text-muted-foreground">İkon: {stat.iconName}</p>
+                    </div>
+                    <div className="flex space-x-2">
+                      <Button variant="outline" size="sm" onClick={() => alert(`İstatistik ${stat.id} düzenlenecek.`)}>
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button variant="destructive" size="sm" onClick={() => alert(`İstatistik ${stat.id} silinecek.`)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+              {stats.length === 0 && <p className="text-center text-gray-500">Henüz istatistik eklenmemiş.</p>}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Misyon & Vizyon Yönetimi */}
+        <TabsContent value="mission_vision">
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Target className="mr-2 h-5 w-5 text-primary" /> Misyonumuz
+                </CardTitle>
+                <CardDescription>"Hakkımızda" sayfasındaki misyon metnini düzenleyin.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Textarea
+                  value={mission}
+                  onChange={(e) => setMission(e.target.value)}
+                  rows={8}
+                  className="text-base"
+                />
+              </CardContent>
+              <CardFooter>
+                <Button onClick={() => alert("Misyon kaydedildi: " + mission)}>
+                  <Save className="mr-2 h-4 w-4" /> Misyonu Kaydet
+                </Button>
+              </CardFooter>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Eye className="mr-2 h-5 w-5 text-primary" /> Vizyonumuz
+                </CardTitle>
+                <CardDescription>"Hakkımızda" sayfasındaki vizyon metnini düzenleyin.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Textarea
+                  value={vision}
+                  onChange={(e) => setVision(e.target.value)}
+                  rows={8}
+                  className="text-base"
+                />
+              </CardContent>
+              <CardFooter>
+                <Button onClick={() => alert("Vizyon kaydedildi: " + vision)}>
+                  <Save className="mr-2 h-4 w-4" /> Vizyonu Kaydet
+                </Button>
+              </CardFooter>
+            </Card>
+          </div>
+        </TabsContent>
+
+        {/* Eğitim İlkeleri Yönetimi (Placeholder) */}
+        <TabsContent value="principles">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Eğitim İlkelerimiz
+                <Button size="sm" onClick={() => alert("Yeni ilke ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni İlke Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>"Hakkımızda" sayfasındaki eğitim ilkelerini yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-gray-500 py-8">
+                <ListChecks className="mx-auto h-12 w-12 text-gray-400 mb-2" />
+                Eğitim ilkeleri listesi ve yönetim arayüzü burada olacak. (Örn: İkon, Başlık, Açıklama)
+              </p>
+              {/* TODO: İlkeler listesi, ekleme/düzenleme/silme formları */}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Tarihçe Yönetimi (Placeholder) */}
+        <TabsContent value="timeline">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Tarihçemiz
+                <Button size="sm" onClick={() => alert("Yeni tarihçe öğesi ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni Öğe Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>"Hakkımızda" sayfasındaki tarihçe bölümünü yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-gray-500 py-8">
+                <Calendar className="mx-auto h-12 w-12 text-gray-400 mb-2" />
+                Tarihçe listesi ve yönetim arayüzü burada olacak. (Örn: Yıl, Başlık, Açıklama)
+              </p>
+              {/* TODO: Tarihçe listesi, ekleme/düzenleme/silme formları */}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Neden Biz? Yönetimi (Placeholder) */}
+        <TabsContent value="why_us">
+          <Card>
+            <CardHeader>
+              <CardTitle>Neden Bizi Seçmelisiniz?</CardTitle>
+              <CardDescription>"Hakkımızda" sayfasındaki "Neden Biz?" bölümünü yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-gray-500 py-8">
+                Bu bölümdeki maddelerin yönetim arayüzü burada olacak.
+              </p>
+              {/* TODO: Madde listesi, ekleme/düzenleme/silme formları */}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+      </Tabs>
+    </div>
+  );
+};
+
+export default AboutPageSettings;

--- a/src/pages/admin/ContactPageSettings.tsx
+++ b/src/pages/admin/ContactPageSettings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Phone, Mail, MapPin } from 'lucide-react';
+
+const ContactPageSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">İletişim Sayfası Yönetimi</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Phone className="mr-2 h-6 w-6 text-primary" />
+            İletişim Bilgileri ve Form Mesajları
+          </CardTitle>
+          <CardDescription>
+            Bu bölümden "İletişim" sayfasında yer alacak adres, telefon, e-posta gibi bilgileri ve (varsa) iletişim formundan gelen mesajları yönetebilirsiniz.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-gray-500 py-12">
+            <Mail className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+            <p className="text-xl font-semibold">Çok Yakında!</p>
+            <p>İletişim sayfası yönetim modülü şu anda geliştirme aşamasındadır.</p>
+          </div>
+          {/* Gelecekte eklenebilecek bölümler:
+          <div className="mt-6">
+            <h3 className="text-lg font-semibold">İletişim Bilgileri</h3>
+            <p>Form alanları burada olacak (Adres, Telefon, E-posta, Harita vb.)</p>
+          </div>
+          <div className="mt-6">
+            <h3 className="text-lg font-semibold">Gelen Mesajlar</h3>
+            <p>İletişim formundan gelen mesajların listesi burada olacak.</p>
+          </div>
+          */}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ContactPageSettings;

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Home, Info, Settings, Newspaper, Image, Users, BarChart2, ExternalLink } from 'lucide-react';
+
+const quickLinks = [
+  { to: '/admin/home-settings', icon: <Home className="w-6 h-6 text-primary" />, title: 'Anasayfa Yönetimi', description: 'Hero, değerler, branşlar vb. yönetin.' },
+  { to: '/admin/about-settings', icon: <Info className="w-6 h-6 text-primary" />, title: 'Hakkımızda Yönetimi', description: 'Misyon, vizyon, tarihçe vb. yönetin.' },
+  { to: '/admin/news-settings', icon: <Newspaper className="w-6 h-6 text-primary" />, title: 'Haberler Yönetimi', description: 'Duyuruları ve haberleri yönetin.' },
+  { to: '/admin/gallery-settings', icon: <Image className="w-6 h-6 text-primary" />, title: 'Galeri Yönetimi', description: 'Fotoğraf ve videoları yönetin.' },
+  { to: '/admin/teachers-settings', icon: <Users className="w-6 h-6 text-primary" />, title: 'Öğretmenler Yönetimi', description: 'Öğretmen bilgilerini yönetin.' },
+  { to: '/admin/education-settings', icon: <Settings className="w-6 h-6 text-primary" />, title: 'Eğitim İçerikleri', description: 'Eğitim programlarını yönetin.' },
+];
+
+const DashboardPage: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-gradient-to-r from-primary to-green-700 p-6 rounded-lg shadow-md text-white">
+        <h1 className="text-3xl font-bold">Admin Paneline Hoş Geldiniz!</h1>
+        <p className="mt-2 text-lg text-green-100">
+          Bu panel üzerinden web sitenizin içeriklerini kolayca yönetebilirsiniz.
+        </p>
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">Hızlı Erişim</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {quickLinks.map((link) => (
+            <Link to={link.to} key={link.to} className="group">
+              <Card className="hover:shadow-xl hover:border-primary/50 transition-all duration-300 h-full flex flex-col">
+                <CardHeader className="flex flex-row items-center space-x-4 pb-3">
+                  <div className="bg-primary/10 p-3 rounded-full">
+                    {link.icon}
+                  </div>
+                  <CardTitle className="text-xl text-gray-800 group-hover:text-primary transition-colors">{link.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <CardDescription className="text-sm text-gray-600">{link.description}</CardDescription>
+                </CardContent>
+                <div className="p-4 pt-0 text-right">
+                    <ExternalLink className="w-4 h-4 text-gray-400 group-hover:text-primary transition-colors" />
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">Genel İstatistikler</h2>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center">
+              <BarChart2 className="w-6 h-6 mr-2 text-primary" />
+              Site İstatistikleri
+            </CardTitle>
+            <CardDescription>
+              Bu bölümde sitenizle ilgili genel istatistikler gösterilecektir (örneğin, haber sayısı, galeri öğesi vb.).
+              Bu özellik gelecekte eklenecektir.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-gray-600">Yakında...</p>
+            {/* Örnek İstatistikler (ileride dinamik olacak)
+            <div className="grid grid-cols-2 gap-4 mt-4">
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <h3 className="text-sm font-medium text-gray-500">Toplam Haber</h3>
+                <p className="text-2xl font-semibold text-gray-800">12</p>
+              </div>
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <h3 className="text-sm font-medium text-gray-500">Toplam Galeri Öğesi</h3>
+                <p className="text-2xl font-semibold text-gray-800">45</p>
+              </div>
+            </div>
+            */}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/pages/admin/EducationPageSettings.tsx
+++ b/src/pages/admin/EducationPageSettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { BookOpenCheck } from 'lucide-react';
+
+const EducationPageSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Eğitim Sayfası Yönetimi</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <BookOpenCheck className="mr-2 h-6 w-6 text-primary" />
+            Eğitim Programları ve İçerikleri
+          </CardTitle>
+          <CardDescription>
+            Bu bölümden "Eğitimler" sayfasında yer alacak eğitim programlarını, yaş gruplarına göre içerikleri ve diğer detayları yönetebilirsiniz.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-gray-500 py-12">
+            <BookOpenCheck className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+            <p className="text-xl font-semibold">Çok Yakında!</p>
+            <p>Eğitim sayfası içerik yönetim modülü şu anda geliştirme aşamasındadır.</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EducationPageSettings;

--- a/src/pages/admin/GalleryPageSettings.tsx
+++ b/src/pages/admin/GalleryPageSettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Image } from 'lucide-react';
+
+const GalleryPageSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Galeri Yönetimi</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Image className="mr-2 h-6 w-6 text-primary" />
+            Fotoğraf ve Video Galerisi
+          </CardTitle>
+          <CardDescription>
+            Bu bölümden "Galeri" sayfasında yer alacak fotoğraf albümlerini ve videoları yönetebilirsiniz.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-gray-500 py-12">
+            <Image className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+            <p className="text-xl font-semibold">Çok Yakında!</p>
+            <p>Galeri yönetim modülü şu anda geliştirme aşamasındadır.</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default GalleryPageSettings;

--- a/src/pages/admin/HomePageSettings.tsx
+++ b/src/pages/admin/HomePageSettings.tsx
@@ -1,0 +1,208 @@
+import React, { useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { PlusCircle, Edit, Trash2, Save, Image as ImageIcon, List } from "lucide-react";
+// import { useForm, useFieldArray } from "react-hook-form"; // Gelecekte form yönetimi için
+// import { zodResolver } from "@hookform/resolvers/zod"; // Gelecekte validasyon için
+// import * as z from "zod"; // Gelecekte validasyon için
+
+// Örnek veri tipleri (Home.tsx'e benzer)
+interface HeroSlide {
+  id: string;
+  image: string;
+  title: string;
+  subtitle: string;
+  description: string;
+}
+
+interface ValueItem {
+  id: string;
+  // icon: string; // İkon seçimi daha karmaşık olabilir, şimdilik metin olarak tutalım
+  iconName: string; // Lucide ikon ismi veya SVG kodu
+  title: string;
+  description: string;
+}
+
+interface SubjectItem {
+  id: string;
+  // icon: string;
+  iconName: string;
+  name: string;
+  image: string;
+}
+
+interface AgeGroupItem {
+  id: string;
+  title: string;
+  description: string;
+  image: string;
+  features: string[];
+}
+
+// Mock Data (Başlangıç için)
+const initialHeroSlides: HeroSlide[] = [
+  { id: '1', image: '/images/hero/hero1.jpg', title: 'Seçkin Eğitimle Büyüyoruz', subtitle: 'Çekirdek Anaokulu\'na Hoşgeldiniz', description: 'Çocuklarınız için sevgi dolu, güvenli ve eğlenceli bir öğrenme ortamı' },
+  { id: '2', image: '/images/hero/hero2.png', title: 'Doğa ile İç İçe Eğitim', subtitle: 'Keşfederek Öğreniyoruz', description: 'Doğal çevrede oyun temelli öğrenme deneyimi' },
+];
+
+const HomePageSettings: React.FC = () => {
+  const [heroSlides, setHeroSlides] = useState<HeroSlide[]>(initialHeroSlides);
+  // Diğer bölümler için de state'ler eklenecek (kuruluş amacı, değerler, branşlar vb.)
+  const [kurulusAmaci, setKurulusAmaci] = useState<string>(
+    "Gelecek, yaşamdan ne istediğimize bağlıdır. Çocuklarımızın mutlu, sağlıklı, \n" +
+    "yaratıcı ve özgüven sahibi bireyler olarak yetişmeleri için en uygun ortamı \n" +
+    "hazırlayarak, onları hayata hazırlamak temel amacımızdır."
+  ); // Home.tsx'den örnek metin
+
+  // TODO: Diğer bölümler için CRUD fonksiyonları ve formlar eklenecek
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Anasayfa İçerik Yönetimi</h1>
+
+      <Tabs defaultValue="hero" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 md:grid-cols-3 lg:grid-cols-5 mb-4">
+          <TabsTrigger value="hero">Hero Slider</TabsTrigger>
+          <TabsTrigger value="kurulus">Kuruluş Amacı</TabsTrigger>
+          <TabsTrigger value="degerler">Değerlerimiz</TabsTrigger>
+          <TabsTrigger value="branslar">Branş Dersleri</TabsTrigger>
+          <TabsTrigger value="psikolojik">Psikolojik Danışmanlık</TabsTrigger>
+          <TabsTrigger value="yasgruplari">Yaş Grupları</TabsTrigger>
+          <TabsTrigger value="onkayit">Ön Kayıt CTA</TabsTrigger>
+        </TabsList>
+
+        {/* Hero Slider Yönetimi */}
+        <TabsContent value="hero">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Hero Slider Öğeleri
+                <Button size="sm" onClick={() => alert("Yeni slayt ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni Slayt Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>Anasayfadaki hero slider'da görünecek slaytları yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {heroSlides.map((slide) => (
+                <Card key={slide.id} className="p-4 shadow-sm">
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <h3 className="font-semibold text-lg">{slide.title}</h3>
+                      <p className="text-sm text-gray-500">{slide.subtitle}</p>
+                      <p className="text-sm text-gray-600 mt-1">{slide.description}</p>
+                      <p className="text-xs text-muted-foreground mt-1">Resim: {slide.image}</p>
+                    </div>
+                    <div className="flex space-x-2">
+                      <Button variant="outline" size="sm" onClick={() => alert(`Slayt ${slide.id} düzenlenecek.`)}>
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button variant="destructive" size="sm" onClick={() => alert(`Slayt ${slide.id} silinecek.`)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+              {heroSlides.length === 0 && <p className="text-center text-gray-500">Henüz slayt eklenmemiş.</p>}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Kuruluş Amacı Yönetimi */}
+        <TabsContent value="kurulus">
+          <Card>
+            <CardHeader>
+              <CardTitle>Kuruluş Amacı Metni</CardTitle>
+              <CardDescription>Anasayfada "Kuruluş Amacımız" bölümünde görünecek metni düzenleyin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Textarea
+                value={kurulusAmaci}
+                onChange={(e) => setKurulusAmaci(e.target.value)}
+                rows={10}
+                className="text-base"
+              />
+            </CardContent>
+            <CardFooter>
+              <Button onClick={() => alert("Kuruluş amacı kaydedildi: " + kurulusAmaci)}>
+                <Save className="mr-2 h-4 w-4" /> Değişiklikleri Kaydet
+              </Button>
+            </CardFooter>
+          </Card>
+        </TabsContent>
+
+        {/* Değerlerimiz Yönetimi (Placeholder) */}
+        <TabsContent value="degerler">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Değerlerimiz
+                <Button size="sm" onClick={() => alert("Yeni değer ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni Değer Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>Anasayfadaki "Değerlerimiz" bölümünü yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-gray-500 py-8">
+                <List className="mx-auto h-12 w-12 text-gray-400 mb-2" />
+                Değerler listesi ve yönetim arayüzü burada olacak. (Örn: İkon, Başlık, Açıklama)
+              </p>
+              {/* TODO: Değerler listesi, ekleme/düzenleme/silme formları */}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Branş Dersleri Yönetimi (Placeholder) */}
+        <TabsContent value="branslar">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                Branş Dersleri
+                <Button size="sm" onClick={() => alert("Yeni branş dersi ekleme formu açılacak.")}>
+                  <PlusCircle className="mr-2 h-4 w-4" /> Yeni Ders Ekle
+                </Button>
+              </CardTitle>
+              <CardDescription>Anasayfadaki "Branş Derslerimiz" bölümünü yönetin.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-center text-gray-500 py-8">
+                <ImageIcon className="mx-auto h-12 w-12 text-gray-400 mb-2" />
+                Branş dersleri listesi ve yönetim arayüzü burada olacak. (Örn: İkon, İsim, Resim)
+              </p>
+              {/* TODO: Branş dersleri listesi, ekleme/düzenleme/silme formları */}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Diğer Tablar için Placeholder */}
+        <TabsContent value="psikolojik">
+          <Card>
+            <CardHeader><CardTitle>Psikolojik Danışmanlık</CardTitle></CardHeader>
+            <CardContent><p className="text-center text-gray-500 py-8">Bu bölümün içerik yönetimi burada olacak.</p></CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="yasgruplari">
+          <Card>
+            <CardHeader><CardTitle>Yaş Grupları</CardTitle></CardHeader>
+            <CardContent><p className="text-center text-gray-500 py-8">Bu bölümün içerik yönetimi burada olacak.</p></CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="onkayit">
+          <Card>
+            <CardHeader><CardTitle>Ön Kayıt CTA</CardTitle></CardHeader>
+            <CardContent><p className="text-center text-gray-500 py-8">Bu bölümün içerik yönetimi burada olacak.</p></CardContent>
+          </Card>
+        </TabsContent>
+
+      </Tabs>
+    </div>
+  );
+};
+
+export default HomePageSettings;

--- a/src/pages/admin/LoginPage.tsx
+++ b/src/pages/admin/LoginPage.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button'; // Shadcn/ui button
+import { Input } from '@/components/ui/input';   // Shadcn/ui input
+import { Label } from '@/components/ui/label';   // Shadcn/ui label
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'; // Shadcn/ui card
+import { LogIn } from 'lucide-react';
+
+const LoginPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Gerçek kimlik doğrulama burada yapılabilir.
+    // Şimdilik direkt dashboard'a yönlendiriyoruz.
+    console.log('Giriş denemesi yapıldı.');
+    navigate('/admin/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-green-100 via-yellow-50 to-orange-100 p-4">
+      <Card className="w-full max-w-md shadow-2xl">
+        <CardHeader className="space-y-1 text-center">
+          <div className="flex justify-center mb-4">
+            <div className="bg-primary text-primary-foreground rounded-full p-3">
+              <LogIn size={32} />
+            </div>
+          </div>
+          <CardTitle className="text-3xl font-bold text-primary">Admin Girişi</CardTitle>
+          <CardDescription>
+            Lütfen devam etmek için giriş yapın.
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="username" className="text-base font-medium text-gray-700">Kullanıcı Adı</Label>
+              <Input
+                id="username"
+                type="text"
+                placeholder="kullanici_adi"
+                defaultValue="admin" // Demo için varsayılan
+                className="text-base"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password"className="text-base font-medium text-gray-700">Şifre</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="********"
+                defaultValue="password" // Demo için varsayılan
+                className="text-base"
+                required
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col">
+            <Button type="submit" className="w-full text-lg py-3 bg-primary hover:bg-primary/90">
+              <LogIn className="mr-2 h-5 w-5" /> Giriş Yap
+            </Button>
+            <p className="mt-4 text-xs text-center text-gray-500">
+              Bu panel sadece yetkili kullanıcılar içindir.
+            </p>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/admin/NewsPageSettings.tsx
+++ b/src/pages/admin/NewsPageSettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Newspaper } from 'lucide-react';
+
+const NewsPageSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Haberler ve Duyurular Yönetimi</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Newspaper className="mr-2 h-6 w-6 text-primary" />
+            Haberler, Etkinlikler ve Duyurular
+          </CardTitle>
+          <CardDescription>
+            Bu bölümden "Duyurular" sayfasında (veya anasayfadaki ilgili bölümde) yer alacak haberleri, etkinlikleri ve duyuruları yönetebilirsiniz.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-gray-500 py-12">
+            <Newspaper className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+            <p className="text-xl font-semibold">Çok Yakında!</p>
+            <p>Haberler ve duyurular yönetim modülü şu anda geliştirme aşamasındadır.</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default NewsPageSettings;

--- a/src/pages/admin/TeachersPageSettings.tsx
+++ b/src/pages/admin/TeachersPageSettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Users } from 'lucide-react';
+
+const TeachersPageSettings: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Öğretmenler Yönetimi</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Users className="mr-2 h-6 w-6 text-primary" />
+            Öğretmen Kadrosu
+          </CardTitle>
+          <CardDescription>
+            Bu bölümden "Öğretmenlerimiz" sayfasında yer alacak öğretmen bilgilerini (fotoğraf, branş, açıklama vb.) yönetebilirsiniz.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-gray-500 py-12">
+            <Users className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+            <p className="text-xl font-semibold">Çok Yakında!</p>
+            <p>Öğretmenler yönetim modülü şu anda geliştirme aşamasındadır.</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TeachersPageSettings;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,6 +50,14 @@ module.exports = {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))',
 				},
+        // Sidebar renkleri için CSS değişkenlerini kullanan tanımlar
+        sidebar: 'hsl(var(--sidebar-background))',
+        'sidebar-foreground': 'hsl(var(--sidebar-foreground))',
+        'sidebar-primary': 'hsl(var(--sidebar-primary))',
+        'sidebar-primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+        'sidebar-accent': 'hsl(var(--sidebar-accent))',
+        'sidebar-accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+        'sidebar-border': 'hsl(var(--sidebar-border))',
 			},
 			borderRadius: {
 				lg: 'var(--radius)',


### PR DESCRIPTION
This commit introduces the foundational structure for the admin panel.

Key features added:
- Admin layout with a sidebar for navigation.
- Routing for admin sections (/admin/*).
- A simple login page (UI only, no auth logic).
- A dashboard page with quick links.
- Skeleton management pages for Home and About sections using Tabs.
- Placeholder pages for Education, Gallery, News, Teachers, and Contact management modules.
- Utilized existing Shadcn/ui components and Tailwind CSS for styling, ensuring consistency with the main site's theme.

Further development will focus on implementing CRUD functionalities within these modules and integrating data management.