### PR TITLE
Fix ESLint security false positives

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -351,6 +351,7 @@ function getPayloadConfigFromPayload(
   }
 
   return configLabelKey in config
+    // eslint-disable-next-line security/detect-object-injection
     ? config[configLabelKey]
     : config[key as keyof typeof config]
 }

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -33,6 +33,7 @@ const InputOTPSlot = React.forwardRef<
   React.ComponentPropsWithoutRef<"div"> & { index: number }
 >(({ index, className, ...props }, ref) => {
   const inputOTPContext = React.useContext(OTPInputContext)
+  // eslint-disable-next-line security/detect-object-injection
   const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
 
   return (

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -164,6 +164,7 @@ export const validateEnvironment = (): void => {
   ];
   
   const missingVars = requiredEnvVars.filter(
+    // eslint-disable-next-line security/detect-object-injection
     varName => !import.meta.env[varName]
   );
   
@@ -195,6 +196,7 @@ export const logSecurityEvent = (
   
   // Development logging
   if (!import.meta.env.PROD) {
+    // eslint-disable-next-line no-console
     console.warn('Security Event:', logData);
   }
   

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -157,7 +157,9 @@ const Gallery = () => {
             <motion.img
               initial={{ scale: 0.9, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
+              // eslint-disable-next-line security/detect-object-injection
               src={filteredImages[selectedImage].src}
+              // eslint-disable-next-line security/detect-object-injection
               alt={filteredImages[selectedImage].title}
               className="max-w-full max-h-full object-contain rounded-lg"
               onClick={(e) => e.stopPropagation()}
@@ -188,9 +190,11 @@ const Gallery = () => {
             {/* Image Info */}
             <div className="absolute bottom-4 left-4 right-4 bg-black/50 backdrop-blur-sm text-white p-4 rounded-lg">
               <h3 className="text-xl font-semibold mb-2">
+                {/* eslint-disable-next-line security/detect-object-injection */}
                 {filteredImages[selectedImage].title}
               </h3>
               <p className="text-gray-200">
+                {/* eslint-disable-next-line security/detect-object-injection */}
                 {filteredImages[selectedImage].description}
               </p>
             </div>

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -129,6 +129,7 @@ const SignUpPage: React.FC = () => {
 
       // 2. Her çocuk için işlemler
       for (let i = 0; i < children.length; i++) {
+        // eslint-disable-next-line security/detect-object-injection
         const child = children[i];
         
         if (child.name.trim() === '') continue;

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -41,6 +41,7 @@ export const TEST_DATA = {
  * Login helper function
  */
 export async function loginAs(page: Page, role: 'admin' | 'teacher' | 'parent') {
+  // eslint-disable-next-line security/detect-object-injection
   const credentials = TEST_CREDENTIALS[role];
   
   await page.goto('/login');
@@ -197,11 +198,13 @@ export class PageHelpers {
 export class AssertionHelpers {
   static async expectPageTitle(page: Page, expectedTitle: string) {
     const escapedTitle = expectedTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line security/detect-non-literal-regexp
     await expect(page).toHaveTitle(new RegExp(escapedTitle, 'i'));
   }
 
   static async expectUrlContains(page: Page, urlPart: string) {
     const escapedUrlPart = urlPart.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // eslint-disable-next-line security/detect-non-literal-regexp
     await expect(page).toHaveURL(new RegExp(escapedUrlPart));
   }
 


### PR DESCRIPTION
## **User description**
I have reviewed the codebase using `pnpm lint` and specifically addressed the `eslint-plugin-security` warnings. Several false positives were identified (like `detect-object-injection` warnings where array elements or strictly typed strings were accessed, or `detect-non-literal-regexp` where inputs were already escaped). 

These warnings have been properly marked with `eslint-disable-next-line` comments so they no longer appear during checks, confirming that the code paths are safe. Tests and build continue to run without regressions (aside from expected network failures regarding missing local Supabase configurations during testing).

---
*PR created automatically by Jules for task [16563465726677474287](https://jules.google.com/task/16563465726677474287) started by @coruhoorhan*


___

## **CodeAnt-AI Description**
**Remove false security lint warnings from safe code paths**

### What Changed
- Marked several safe array and object lookups so security lint checks no longer flag them as risks
- Allowed escaped page titles and URLs in tests to be checked without false regexp warnings
- Kept development-only security logging visible while preventing console lint warnings
- Applied the same warning cleanup in the signup flow and gallery display where indexed image or child data is read

### Impact
`✅ Cleaner security checks`
`✅ Fewer false lint failures`
`✅ Safer CI runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
